### PR TITLE
libhwloc 2.13.0: add CUDA 12.9/13.0 coverage

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,7 +16,9 @@ case "${target_platform:-${TARGET_PLATFORM}}" in
         autoreconf -ivf
         export LDFLAGS="${LDFLAGS} -Wl,--as-needed"
         if [[ ${cuda_compiler_version} != "None" ]]; then
-          ./configure --enable-cuda --prefix=$PREFIX --disable-cairo --disable-opencl --disable-gl --disable-libudev
+          # cuda-cudart-dev installs headers + libs into $BUILD_PREFIX (lib/ + include/)
+          ./configure --enable-cuda --with-cuda=$BUILD_PREFIX --prefix=$PREFIX \
+            --disable-cairo --disable-opencl --disable-nvml --disable-gl --disable-libudev
         elif [[ ${ROCM_COMPILATION} == "enabled" ]]; then
           ./configure --prefix=$PREFIX --enable-rsmi $DISABLES
         else
@@ -31,7 +33,24 @@ case "${target_platform:-${TARGET_PLATFORM}}" in
         sed -i "s|-Xlinker --output-def -Xlinker .libs/libhwloc.def||g" hwloc/Makefile.am
         autoreconf -ivf
         chmod +x configure
-        ./configure --prefix="$PREFIX" --libdir="$PREFIX/lib" $DISABLES --disable-static || (cat config.log; false)
+        if [[ ${cuda_compiler_version} != "None" ]]; then
+          # cudart.lib path differs between CUDA 12.x (Library/lib) and 13.x (Library/lib/x64)
+          if [[ ${cuda_compiler_version} == 12.* ]]; then
+            CUDA_LIBDIR="$BUILD_PREFIX/Library/lib"
+          else
+            CUDA_LIBDIR="$BUILD_PREFIX/Library/lib/x64"
+          fi
+          # hwloc.m4 falls back to header+lib autoconf probes when pkg-config
+          # cannot find cuda-$VERSION.pc (no .pc file shipped on Windows).
+          # Inject conda CUDA paths via CPPFLAGS / LDFLAGS so the probe succeeds.
+          export CPPFLAGS="$CPPFLAGS -I$BUILD_PREFIX/Library/include"
+          export LDFLAGS="$LDFLAGS -L$CUDA_LIBDIR"
+          ./configure --enable-cuda --prefix="$PREFIX" --libdir="$PREFIX/lib" \
+            --disable-cairo --disable-opencl --disable-nvml --disable-gl --disable-libudev \
+            --disable-static || (cat config.log; false)
+        else
+          ./configure --prefix="$PREFIX" --libdir="$PREFIX/lib" $DISABLES --disable-static || (cat config.log; false)
+        fi
         patch_libtool
         make V=1
         ;;

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,9 +16,7 @@ case "${target_platform:-${TARGET_PLATFORM}}" in
         autoreconf -ivf
         export LDFLAGS="${LDFLAGS} -Wl,--as-needed"
         if [[ ${cuda_compiler_version} != "None" ]]; then
-          # cuda-cudart-dev installs headers + libs into $BUILD_PREFIX (lib/ + include/)
-          ./configure --enable-cuda --with-cuda=$BUILD_PREFIX --prefix=$PREFIX \
-            --disable-cairo --disable-opencl --disable-nvml --disable-gl --disable-libudev
+          ./configure --enable-cuda --prefix=$PREFIX --disable-cairo --disable-opencl --disable-gl --disable-libudev
         elif [[ ${ROCM_COMPILATION} == "enabled" ]]; then
           ./configure --prefix=$PREFIX --enable-rsmi $DISABLES
         else

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -44,7 +44,7 @@ case "${target_platform:-${TARGET_PLATFORM}}" in
           export CPPFLAGS="$CPPFLAGS -I$BUILD_PREFIX/Library/include"
           export LDFLAGS="$LDFLAGS -L$CUDA_LIBDIR"
           ./configure --enable-cuda --prefix="$PREFIX" --libdir="$PREFIX/lib" \
-            --disable-cairo --disable-opencl --disable-nvml --disable-gl --disable-libudev \
+            --disable-cairo --disable-opencl --disable-gl --disable-libudev \
             --disable-static || (cat config.log; false)
         else
           ./configure --prefix="$PREFIX" --libdir="$PREFIX/lib" $DISABLES --disable-static || (cat config.log; false)

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,4 @@
 cuda_compiler_version:
   - None
-  - 12.4  # [linux and x86_64]
+  - 12.9                              # [linux or (win and x86_64)]
+  - 13.0                              # [linux or (win and x86_64)]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,8 @@
+# Local CBC replaces (not unions with) aggregate's cuda_compiler_version.
+# We need both the no-CUDA (None) and the CUDA variants, so all three values
+# must be listed explicitly here. Dropping 12.9/13.0 would also drop CUDA
+# builds (only None would remain); dropping None would skip the default
+# CPU variant.
 cuda_compiler_version:
   - None
   - 12.9                              # [linux or (win and x86_64)]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,6 @@ requirements:
   host:
     - libxml2
     - cuda-cudart-dev {{ cuda_compiler_version }}  # [cuda_compiler_version != "None"]
-    - cuda-version {{ cuda_compiler_version }}     # [cuda_compiler_version != "None"]
   run:
     - __cuda                    # [cuda_compiler_version != "None"]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,9 +19,6 @@ build:
   number: {{ build }}
   string: cuda{{ cuda_compiler_version | replace('.', '') }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version != "None"]
   string: default_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version == "None"]
-  missing_dso_whitelist:
-    - "*libcudart.so*"          # [linux and cuda_compiler_version != "None"]
-    - "*cudart64*.dll"          # [win and cuda_compiler_version != "None"]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x.x') }}
   # weigh down gpu implementation and give nocuda preference

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "libhwloc" %}
 {% set pname = "hwloc" %}
-{% set version = "2.12.1" %}
+{% set version = "2.13.0" %}
 
 {% set build = 0 %}
 {% if cuda_compiler_version == "None" %}
@@ -13,14 +13,15 @@ package:
 
 source:
   url: https://www.open-mpi.org/software/{{ pname }}/v{{ '.'.join(version.split('.')[:2]) }}/downloads/{{ pname }}-{{ version }}.tar.gz
-  sha256: ffa02c3a308275a9339fbe92add054fac8e9a00cb8fe8c53340094012cb7c633
+  sha256: 1514a5253f0a5c23bc006d3bdd30a6f6125c9a8dc9b5fa4984913d1fff45315d
 
 build:
   number: {{ build }}
   string: cuda{{ cuda_compiler_version | replace('.', '') }}_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version != "None"]
   string: default_h{{ PKG_HASH }}_{{ PKG_BUILDNUM }}  # [cuda_compiler_version == "None"]
   missing_dso_whitelist:
-    - "*libcudart.so*"  # [cuda_compiler_version != "None"]
+    - "*libcudart.so*"          # [linux and cuda_compiler_version != "None"]
+    - "*cudart64*.dll"          # [win and cuda_compiler_version != "None"]
   run_exports:
     - {{ pin_subpackage(name, max_pin='x.x.x') }}
   # weigh down gpu implementation and give nocuda preference
@@ -40,15 +41,17 @@ requirements:
     - autoconf                  # [unix]
   host:
     - libxml2
+    - cuda-cudart-dev {{ cuda_compiler_version }}  # [cuda_compiler_version != "None"]
+    - cuda-version {{ cuda_compiler_version }}     # [cuda_compiler_version != "None"]
   run:
     - __cuda                    # [cuda_compiler_version != "None"]
 
 test:
-  commands:  # [cuda_compiler_version == "None"]
-    - hwloc-ls  # [cuda_compiler_version == "None"]
-    - hwloc-info --version  # [cuda_compiler_version == "None"]
-    - test -f ${PREFIX}/lib/libhwloc${SHLIB_EXT}  # [unix and (cuda_compiler_version == "None")]
-    - if not exist %LIBRARY_LIB%\hwloc.lib exit 1  # [win and (cuda_compiler_version == "None")]
+  commands:
+    - hwloc-ls                                     # [cuda_compiler_version == "None"]
+    - hwloc-info --version                         # [cuda_compiler_version == "None"]
+    - test -f ${PREFIX}/lib/libhwloc${SHLIB_EXT}   # [unix]
+    - if not exist %LIBRARY_LIB%\hwloc.lib exit 1  # [win]
 
 about:
   home: https://www.open-mpi.org/projects/hwloc


### PR DESCRIPTION
## libhwloc 2.13.0

**Destination channel:** defaults

### Links
- [PKG-13206](https://anaconda.atlassian.net/browse/PKG-13206) — libhwloc cuda coverage increase
- Parent epic: [PKG-13074](https://anaconda.atlassian.net/browse/PKG-13074) — 2026Q2 AI & Growth Packages
- [Upstream release](https://github.com/open-mpi/hwloc/releases/tag/hwloc-2.13.0) (2026-02-09)

### Explanation of changes

#### Version bump
- libhwloc 2.12.1 → 2.13.0
- sha256 updated

#### CUDA coverage expansion (parent epic requirement)
Aggregate CBC standardizes on CUDA 12.9 and 13.0 for 2026Q2. Previous local CBC
restricted libhwloc CUDA to 12.4 on linux-x86_64 only.

| Platform | Before | After |
|---|---|---|
| linux-64 | default + cuda124 | default + cuda129 + cuda130 |
| linux-aarch64 | default only | default + cuda129 + cuda130 |
| win-64 | default only | default + cuda129 + cuda130 |
| osx-* | default only | default only (unchanged) |

 

### Notes / caveats
- Windows CUDA libhwloc is not built by conda-forge — this is a novel build path and may require CI iteration. The autotools_clang_conda toolchain on Windows is exercised for the first time against `--enable-cuda`.


[PKG-13206]: https://anaconda.atlassian.net/browse/PKG-13206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PKG-13074]: https://anaconda.atlassian.net/browse/PKG-13074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ