### PR TITLE
Rebuild against libxml2

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -7,3 +7,5 @@ cuda_compiler_version:
   - None
   - 12.9                              # [linux or (win and x86_64)]
   - 13.0                              # [linux or (win and x86_64)]
+libxml2:
+  - 2.14.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - libtool                   # [unix]
     - autoconf                  # [unix]
   host:
-    - libxml2
+    - libxml2 {{ libxml2 }}
     - cuda-cudart-dev {{ cuda_compiler_version }}  # [cuda_compiler_version != "None"]
   run:
     - __cuda                    # [cuda_compiler_version != "None"]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set pname = "hwloc" %}
 {% set version = "2.13.0" %}
 
-{% set build = 0 %}
+{% set build = 1 %}
 {% if cuda_compiler_version == "None" %}
 {% set build = build + 1000 %}
 {% endif %}


### PR DESCRIPTION
libhwloc 2.13.0

**Destination channel:**  defaults

### Links

- [PKG-12533](https://anaconda.atlassian.net/browse/PKG-12533) 
- [Upstream repository](https://github.com/open-mpi/hwloc/tree/hwloc-2.13.0)

### Explanation of changes:
- Build with libxml 2.14.4


[PKG-12533]: https://anaconda.atlassian.net/browse/PKG-12533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ